### PR TITLE
ensure that vector3's are cast to arrays inside of spatial calculations

### DIFF
--- a/geoana/__init__.py
+++ b/geoana/__init__.py
@@ -5,5 +5,5 @@ from . import utils
 __version__ = '0.0.3'
 __author__ = 'SimPEG developers'
 __license__ = 'MIT'
-__copyright__ = 'Copyright 2017 SimPEG developers'
+__copyright__ = 'Copyright 2017-2018 SimPEG developers'
 

--- a/geoana/em/base.py
+++ b/geoana/em/base.py
@@ -63,26 +63,28 @@ class BaseDipole(BaseEM):
         Vector distance from the dipole location
         :param numpy.ndarray xyz: grid
         """
-        return spatial.vector_distance(xyz, self.location)
+        return spatial.vector_distance(xyz, np.array(self.location))
 
     def distance(self, xyz):
         """
         Distance from the dipole location
         """
-        return spatial.distance(xyz, self.location)
+        return spatial.distance(xyz, np.array(self.location))
 
     def dot_orientation(self, xyz):
         """
         Take the dot product between a grid and the orientation of the dipole
         """
-        return spatial.vector_dot(xyz, self.orientation)
+        return spatial.vector_dot(xyz, np.array(self.orientation))
 
     def cross_orientation(self, xyz):
         """
         Take the cross product between a grid and the orientation of the dipole
         """
         orientation = np.kron(
-            np.atleast_2d(self.orientation), np.ones((xyz.shape[0], 1))
+            np.atleast_2d(
+                np.array(self.orientation)), np.ones((xyz.shape[0], 1)
+            )
         )
         return np.cross(xyz, orientation)
 

--- a/geoana/em/static.py
+++ b/geoana/em/static.py
@@ -222,8 +222,8 @@ class CircularLoopWholeSpace(BaseDipole, BaseEM):
             xyz = spatial.cylindrical_2_cartesian(xyz)
 
         xyz = spatial.rotate_points_from_normals(
-            xyz, np.array([i for i in self.orientation]),  # work around for a properties issue
-            np.r_[0., 0., 1.], x0=self.location
+            xyz, np.array(self.orientation),  # work around for a properties issue
+            np.r_[0., 0., 1.], x0=np.array(self.location)
         )
 
         n_obs = xyz.shape[0]
@@ -255,10 +255,10 @@ class CircularLoopWholeSpace(BaseDipole, BaseEM):
 
         # rotate the points to aligned with the normal to the source
         A = spatial.rotate_points_from_normals(
-            A, np.r_[0., 0., 1.], self.orientation, x0=self.location
+            A, np.r_[0., 0., 1.], np.array(self.orientation), x0=self.location
         )
 
         if coordinates.lower() == "cylindrical":
-            A = spatial.cartesian_2_cylindrical(np.array(xyz), A)
+            A = spatial.cartesian_2_cylindrical(xyz, A)
 
         return A

--- a/geoana/em/static.py
+++ b/geoana/em/static.py
@@ -255,7 +255,8 @@ class CircularLoopWholeSpace(BaseDipole, BaseEM):
 
         # rotate the points to aligned with the normal to the source
         A = spatial.rotate_points_from_normals(
-            A, np.r_[0., 0., 1.], np.array(self.orientation), x0=self.location
+            A, np.r_[0., 0., 1.], np.array(self.orientation),
+            x0=np.array(self.location)
         )
 
         if coordinates.lower() == "cylindrical":

--- a/geoana/spatial.py
+++ b/geoana/spatial.py
@@ -414,8 +414,13 @@ def rotate_points_from_normals(xyz, n0, n1, x0=np.r_[0., 0., 0.]):
 
     R = rotation_matrix_from_normals(n0, n1)
 
-    assert xyz.shape[1] == 3, "Grid xyz should be 3 wide"
-    assert len(x0) == 3, "x0 should have length 3"
+    if xyz.shape[1] != 3:
+        raise AssertionError("Grid xyz should be 3 wide")
+
+    if len(x0) != 3:
+        raise AssertionError("x0 should have length 3")
+
+    x0 = np.array(x0.flatten())  # ensure it is an array not a vector3
 
     X0 = np.ones([xyz.shape[0], 1])*mkvc(x0)
-    return np.dot(xyz - X0, R.T) + X0 # equivalent to (R*(XYZ - X0)).T + X0
+    return np.dot(xyz - X0, R.T) + X0  # equivalent to (R*(XYZ - X0)).T + X0

--- a/geoana/spatial.py
+++ b/geoana/spatial.py
@@ -251,6 +251,14 @@ def vector_distance(xyz, origin=np.r_[0., 0., 0.]):
         )
     )
 
+    if len(origin) != 3:
+        raise Exception(
+            "the origin must be length 3, the length provided is {}".format(
+                len(origin)
+            )
+        )
+
+
     dx = xyz[:, 0] - origin[0]
     dy = xyz[:, 1] - origin[1]
     dz = xyz[:, 2] - origin[2]
@@ -294,7 +302,12 @@ def vector_dot(xyz, vector):
               (npoints x 1) array
     :rtype: numpy.ndarray
     """
-    assert len(vector) == 3, "vector should be length 3"
+    if len(vector) != 3:
+        raise Exception(
+            "vector should be length 3, the provided length is {}".format(
+                len(vector)
+            )
+        )
     return vector[0]*xyz[:, 0] + vector[1]*xyz[:, 1] + vector[2]*xyz[:, 2]
 
 

--- a/tests/test_em_static.py
+++ b/tests/test_em_static.py
@@ -7,6 +7,7 @@ import unittest
 import numpy as np
 from scipy.constants import mu_0, epsilon_0
 import discretize
+import properties
 
 from geoana.em import static, fdem
 from geoana import spatial
@@ -33,7 +34,6 @@ class TestEM_Static(unittest.TestCase):
         self.assertTrue(np.all(self.clws.orientation == np.r_[1., 0., 0.]))
 
         self.assertTrue(self.mdws.moment == 1)
-
         self.assertTrue(self.clws.current == 1)
         self.assertTrue(self.clws.radius == 1)
 
@@ -59,6 +59,12 @@ class TestEM_Static(unittest.TestCase):
 
             a_clws = self.clws.vector_potential(mesh.gridCC)[inds]
             a_mdws = self.mdws.vector_potential(mesh.gridCC)[inds]
+
+            self.assertTrue(isinstance(a_clws, np.ndarray))
+            self.assertFalse(isinstance(a_clws, properties.Vector3))
+
+            self.assertTrue(isinstance(a_mdws, np.ndarray))
+            self.assertFalse(isinstance(a_mdws, properties.Vector3))
 
             self.assertTrue(
                 np.linalg.norm(a_clws - a_mdws) <
@@ -112,6 +118,9 @@ class TestEM_Static(unittest.TestCase):
                         fdem_dipole.magnetic_flux_density(mesh.gridFy)[:, 1],
                         fdem_dipole.magnetic_flux_density(mesh.gridFz)[:, 2]
                     ])
+
+                    self.assertTrue(isinstance(b_fdem, np.ndarray))
+                    self.assertFalse(isinstance(b_fdem, properties.Vector3))
 
                     inds = (np.hstack([
                         (np.absolute(mesh.gridFx[:, 0]) > h*2 + location[0]) &


### PR DESCRIPTION
- in the em base, ensure that vector3 properties like the orientation and location of a dipole are cast to arrays before calculations so that the output is always an array 
- add tests to ensure output of the magnetostatic calculations are arrays

fixes #10 