### PR TITLE
fix bug found when transmitter not at surface.

### DIFF
--- a/geoana/em/fdem/layered.py
+++ b/geoana/em/fdem/layered.py
@@ -121,7 +121,7 @@ class MagneticDipoleLayeredHalfSpace(BaseMagneticDipole, BaseFDEM):
         rTE = rTE.reshape((n_frequency, *lambd.shape))
 
         # secondary is height of receiver plus height of source
-        rTE *= np.exp(-lambd*(dxyz[:, -1] + 2*h)[:, None])
+        rTE *= np.exp(-lambd*(xyz[:, -1] + h)[:, None])
         # works for variable xyz because each point has it's own lambdas
 
         src_x, src_y, src_z = self.orientation

--- a/geoana/em/fdem/layered.py
+++ b/geoana/em/fdem/layered.py
@@ -92,7 +92,7 @@ class MagneticDipoleLayeredHalfSpace(BaseMagneticDipole, BaseFDEM):
 
         if np.any(xyz[:, 2] < 0.0):
             raise ValueError("Cannot compute fields below the surface")
-        h = self.location[0]
+        h = self.location[2]
         dxyz = xyz - self.location
         offsets = np.linalg.norm(dxyz[:, :-1], axis=-1)
 
@@ -121,7 +121,7 @@ class MagneticDipoleLayeredHalfSpace(BaseMagneticDipole, BaseFDEM):
         rTE = rTE.reshape((n_frequency, *lambd.shape))
 
         # secondary is height of receiver plus height of source
-        rTE *= np.exp(-lambd*(xyz[:, -1] + h)[:, None])
+        rTE *= np.exp(-lambd*(dxyz[:, -1] + 2*h)[:, None])
         # works for variable xyz because each point has it's own lambdas
 
         src_x, src_y, src_z = self.orientation


### PR DESCRIPTION
I found a bug in the forward simulation for em1dfm for a layered Earth. The bug happens when the transmitter is not on the surface. I have fixed the code and validated the new code against cyl mesh and octree codes in SimPEG.

![image](https://user-images.githubusercontent.com/12970009/102158463-5cbd5480-3e36-11eb-9c7f-be10ef9d3d07.png)
