### PR TITLE
bug fix for import error

### DIFF
--- a/geoana/kernels/__init__.py
+++ b/geoana/kernels/__init__.py
@@ -1,3 +1,4 @@
 """This module contains kernals for (semi-)analytic geophysical responses
 """
 from geoana.kernels.tranverse_electric_reflections import rTE_forward, rTE_gradient
+from . import _extensions


### PR DESCRIPTION
import error in `\geoana\geoana\kernels\_extensions`. 

also, it seems the current conda version does not include latest implementations in the above folder. Am I right @jcapriot ?