### PR TITLE
bug fix for halfspace receivers, and example for proper broadcasting

### DIFF
--- a/geoana/em/fdem/base.py
+++ b/geoana/em/fdem/base.py
@@ -20,12 +20,12 @@ def omega(frequency):
 
     Parameters
     ----------
-    frequency : float, (n) numpy.ndarray
+    frequency : float, numpy.ndarray
         frequency or frequencies (Hz)
 
     Returns
     -------
-    float, (n) numpy.ndarray
+    float, numpy.ndarray
         Angular frequency or frequencies in rad/s
 
     """

--- a/geoana/em/fdem/halfspace.py
+++ b/geoana/em/fdem/halfspace.py
@@ -27,14 +27,14 @@ class MagneticDipoleHalfSpace(BaseFDEM, BaseMagneticDipole):
 
         Parameters
         ----------
-        xy : numpy.ndarray
-            receiver locations of shape (n_locations, 2)
+        xy : (..., 2) numpy.ndarray
+            receiver locations of shape
         field : ("secondary", "total")
             Flag for the type of field to return.
 
         Returns
         -------
-        (n_freq, n_loc, 3) numpy.array of complex
+        (n_freq, ..., 3) numpy.array of complex
             Magnetic field at all frequencies for the gridded
             locations provided. Output array is squeezed when n_freq and/or
             n_loc = 1.
@@ -82,25 +82,22 @@ class MagneticDipoleHalfSpace(BaseFDEM, BaseMagneticDipole):
 
         """
         f = self.frequency
-        n_freq = len(f)
         sig = self.sigma_hat
         w = 2*np.pi*f
-        k = np.sqrt(-1j*w*mu_0*sig)[:, None]
+        k = np.sqrt(-1j*w*mu_0*sig)  # K shape is (n_freq, )
 
-        dxy = xy[:, :2] - self.location[:2]
+        dxy = xy[..., :2] - self.location[:2]
         r = np.linalg.norm(dxy, axis=-1)
-        n_loc = len(r)
-        x = dxy[:, 0]
-        y = dxy[:, 1]
+        x = dxy[..., 0]
+        y = dxy[..., 1]
 
-        em_x = em_y = em_z = np.zeros((n_freq, n_loc), dtype=complex)
+        for dim in range(r.ndim):
+            k = k[:, None]
+
+        em_x = em_y = em_z = 0
         src_x, src_y, src_z = self.orientation
 
-        # tile such that (n_freq, n_loc)
-        alpha = 1j * np.outer(k, r) / 2
-        r = np.tile(r.reshape((1, n_loc)), (n_freq, 1))
-        k = np.tile(k.reshape((n_freq, 1)), (1, n_loc))
-        # alpha = 1j*k*r/2.
+        alpha = 1j*k*r/2.  # (n_freq, ...) * (...)
         IK1 = iv(1, alpha)*kv(1, alpha)
         IK2 = iv(2, alpha)*kv(2, alpha)
 
@@ -109,12 +106,8 @@ class MagneticDipoleHalfSpace(BaseFDEM, BaseMagneticDipole):
             em_z += src_z*2.0/(k**2*r**5)*(9-(9+9*1j*k*r-4*k**2*r**2-1j*k**3*r**3)*np.exp(-1j*k*r))
             Hr = (k**2/r)*(IK1 - IK2)
             angle = np.arctan2(y, x)
-            angle = np.tile(angle.reshape((1, n_loc)), (n_freq, 1))
             em_x += src_z*np.cos(angle)*Hr
             em_y += src_z*np.sin(angle)*Hr
-
-        x = np.tile(x.reshape((1, n_loc)), (n_freq, 1))
-        y = np.tile(y.reshape((1, n_loc)), (n_freq, 1))
 
         if src_x != 0.0 or src_y != 0.0:
             # X component of source
@@ -133,7 +126,7 @@ class MagneticDipoleHalfSpace(BaseFDEM, BaseMagneticDipole):
 
         if field == "secondary":
             # subtract out primary field from above
-            mdotr = src_x*x + src_y*y# + m[2]*(z=0)
+            mdotr = src_x*x + src_y*y # + m[2]*(z=0)
 
             em_x -= 3*x*mdotr/r**5 - src_x/r**3
             em_y -= 3*y*mdotr/r**5 - src_y/r**3

--- a/geoana/em/fdem/wholespace.py
+++ b/geoana/em/fdem/wholespace.py
@@ -33,12 +33,12 @@ class ElectricDipoleWholeSpace(BaseFDEM, BaseElectricDipole):
 
         Parameters
         ----------
-        xyz : (n, 3) numpy.ndarray
+        xyz : (..., 3) numpy.ndarray
             Gridded xyz locations
 
         Returns
         -------
-        (n_freq, n_loc, 3) numpy.array of complex
+        (n_freq, ..., 3) numpy.array of complex
             Magnetic vector potential at all frequencies for the gridded
             locations provided. Output array is squeezed when n_freq and/or
             n_loc = 1.
@@ -90,29 +90,13 @@ class ElectricDipoleWholeSpace(BaseFDEM, BaseElectricDipole):
         >>> ax2.autoscale(tight=True)
 
         """
-        # r = self.distance(xyz)
-        # a = (
-        #     (self.current * self.length) / (4*np.pi*r) *
-        #     np.exp(-1j*self.wavenumber*r)
-        # )
-        # a = np.kron(np.ones(1, 3), np.atleast_2d(a).T)
-        # return self.dot_orientation(a)
-
-        n_freq = len(self.frequency)
-        n_loc = np.shape(xyz)[0]
-
-        r = self.distance(xyz)
+        r = np.linalg.norm(xyz - self.location, axis=-1)
         k = self.wavenumber
+        for dim in range(r.ndim):
+            k = k[:, None]
 
-        # (n_freq, n_loc) array
-        a = self.current * self.length * (
-            1 / (4*np.pi*np.tile(r.reshape((1, n_loc)), (n_freq, 1))) *
-            np.exp(-1j*np.outer(k, r))
-        )
-
-        v = self.orientation.reshape(1, 1, 3)
-        a = a.reshape((n_freq, n_loc, 1))
-        return np.kron(v, a).squeeze()
+        a = self.current * self.length / (4*np.pi*r) * np.exp(-1j*k * r)
+        return (a[..., None] * self.orientation).squeeze()
 
     def electric_field(self, xyz):
         r"""Electric field for the harmonic current dipole at a set of gridded locations.
@@ -136,12 +120,12 @@ class ElectricDipoleWholeSpace(BaseFDEM, BaseElectricDipole):
 
         Parameters
         ----------
-        xyz : (n, 3) numpy.ndarray
+        xyz : (..., 3) numpy.ndarray
             Gridded xyz locations
 
         Returns
         -------
-        (n_freq, n_loc, 3) numpy.array of complex
+        (n_freq, ..., 3) numpy.array of complex
             Electric field at all frequencies for the gridded
             locations provided. Output array is squeezed when n_freq and/or
             n_loc = 1.
@@ -196,55 +180,25 @@ class ElectricDipoleWholeSpace(BaseFDEM, BaseElectricDipole):
         >>> ax2.set_title('Imag component {} Hz'.format(frequency[f_ind]))
 
         """
-        # dxyz = self.vector_distance(xyz)
-        # r = repeat_scalar(self.distance(xyz))
-        # kr = self.wavenumber * r
-        # ikr = 1j * kr
-
-        # front_term = (
-        #     (self.current * self.length) / (4 * np.pi * self.sigma * r**3) *
-        #     np.exp(-ikr)
-        # )
-        # symmetric_term = (
-        #     repeat_scalar(self.dot_orientation(dxyz)) * dxyz *
-        #     (-kr**2 + 3*ikr + 3) / r**2
-        # )
-        # oriented_term = (
-        #     (kr**2 - ikr - 1) *
-        #     np.kron(self.orientation, np.ones((dxyz.shape[0], 1)))
-        # )
-        # return front_term * (symmetric_term + oriented_term)
-
-        n_freq = len(self.frequency)
-        n_loc = np.shape(xyz)[0]
-
+        dxyz = xyz - self.location
+        r = np.linalg.norm(dxyz, axis=-1)
         k = self.wavenumber
-        r = self.distance(xyz)
-        dxyz = self.vector_distance(xyz)
+        for dim in range(r.ndim):
+            k = k[:, None]
 
-        # (n_freq, n_loc) arrays
-        kr = np.outer(k, r)
+        kr = k * r
         ikr = 1j * kr
-        tile_r = np.outer(np.ones(n_freq), r)
 
-        front_term = (self.current * self.length) * (
-            1 / (4 * np.pi * self.sigma * tile_r**3) * np.exp(-ikr)
-        ).reshape((n_freq, n_loc, 1))
-        front_term = np.tile(front_term, (1, 1, 3))
+        front_term = (
+            (self.current * self.length) / (4 * np.pi * self.sigma * r**3) *
+            np.exp(-ikr)
+        )
+        symmetric_term = (
+            ((dxyz @ self.orientation) * (-kr**2 + 3*ikr + 3) / r**2)[..., None] * dxyz
+        )
+        oriented_term = (kr**2 - ikr - 1)[..., None] * self.orientation
 
-        temp_1 = repeat_scalar(self.dot_orientation(dxyz)) * dxyz
-        temp_1 = np.tile(temp_1.reshape((1, n_loc, 3)), (n_freq, 1, 1))
-        temp_2 = (-kr**2 + 3*ikr + 3) / tile_r**2
-        temp_2 = np.tile(temp_2.reshape((n_freq, n_loc, 1)), (1, 1, 3))
-        symmetric_term = temp_1 * temp_2
-
-        temp_1 = (kr**2 - ikr - 1)
-        temp_1 = np.tile(temp_1.reshape((n_freq, n_loc, 1)), (1, 1, 3))
-        temp_2 = np.kron(self.orientation, np.ones((dxyz.shape[0], 1)))
-        temp_2 = np.tile(temp_2.reshape((1, n_loc, 3)), (n_freq, 1, 1))
-        oriented_term = temp_1 * temp_2
-
-        return (front_term * (symmetric_term + oriented_term)).squeeze()
+        return (front_term[..., None] * (symmetric_term + oriented_term)).squeeze()
 
     def current_density(self, xyz):
         r"""Current density for the harmonic current dipole at a set of gridded locations.
@@ -351,12 +305,12 @@ class ElectricDipoleWholeSpace(BaseFDEM, BaseElectricDipole):
 
         Parameters
         ----------
-        xyz : (n, 3) numpy.ndarray
+        xyz : (..., 3) numpy.ndarray
             Gridded xyz locations
 
         Returns
         -------
-        (n_freq, n_loc, 3) numpy.array of complex
+        (n_freq, ..., 3) numpy.array of complex
             Magnetic field at all frequencies for the gridded
             locations provided. Output array is squeezed when n_freq and/or
             n_loc = 1.
@@ -411,40 +365,19 @@ class ElectricDipoleWholeSpace(BaseFDEM, BaseElectricDipole):
         >>> ax2.set_title('Imag component {} Hz'.format(frequency[f_ind]))
 
         """
-        # dxyz = self.vector_distance(xyz)
-        # r = repeat_scalar(self.distance(xyz))
-        # kr = self.wavenumber * r
-        # ikr = 1j*kr
-
-        # front_term = (
-        #     self.current * self.length / (4 * np.pi * r**2) * (ikr + 1) *
-        #     np.exp(-ikr)
-        # )
-        # return -front_term * self.cross_orientation(dxyz) / r
-
-        n_freq = len(self.frequency)
-        n_loc = np.shape(xyz)[0]
-
+        dxyz = xyz - self.location
+        r = np.linalg.norm(dxyz, axis=-1)
         k = self.wavenumber
-        r = self.distance(xyz)
+        for dim in range(r.ndim):
+            k = k[:, None]
+        kr = k * r
+        ikr = 1j*kr
 
-        # (n_freq, n_loc)
-        kr = np.outer(k, r)
-        ikr = 1j * kr
-        tile_r = np.outer(np.ones(n_freq), r)
-
-        r = repeat_scalar(r)
-        dxyz = self.vector_distance(xyz)
-
-        first_term = self.current * self.length * (
-            1 / (4 * np.pi * tile_r**2) * (ikr + 1) * np.exp(-ikr)
-        ).reshape((n_freq, n_loc, 1))
-        first_term = np.tile(first_term, (1, 1, 3))
-
-        second_term = (self.cross_orientation(dxyz) / r).reshape((1, n_loc, 3))
-        second_term = np.tile(second_term, (n_freq, 1, 1))
-
-        return -(first_term * second_term).squeeze()
+        front_term = (
+            self.current * self.length / (4 * np.pi * r**2) * (ikr + 1) *
+            np.exp(-ikr)
+        )
+        return (-front_term[..., None] * np.cross(dxyz, self.orientation) / r[..., None]).squeeze()
 
     def magnetic_flux_density(self, xyz):
         r"""Magnetic flux density produced by the harmonic electric current dipole at a set of gridded locations.
@@ -467,12 +400,12 @@ class ElectricDipoleWholeSpace(BaseFDEM, BaseElectricDipole):
 
         Parameters
         ----------
-        xyz : (n, 3) numpy.ndarray
+        xyz : (..., 3) numpy.ndarray
             Gridded xyz locations
 
         Returns
         -------
-        (n_freq, n_loc, 3) numpy.array of complex
+        (n_freq, ..., 3) numpy.array of complex
             Magnetic flux at all frequencies for the gridded
             locations provided. Output array is squeezed when n_freq and/or
             n_loc = 1.


### PR DESCRIPTION
There was a bug introduced in the previous switchover from removing properties in the half-space solution, which is fixed here.

@dccowan this also shows proper numpy broadcasting on the electric-dipole solution, which should be copied into the other dipole solutions.