### PR TITLE
Check xyz

### DIFF
--- a/geoana/em/static/sphere.py
+++ b/geoana/em/static/sphere.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.constants import epsilon_0
-from geoana.utils import check_ndarray_dim
+from geoana.utils import check_xyz_dim
 
 
 class ElectrostaticSphere:
@@ -148,7 +148,7 @@ class ElectrostaticSphere:
         V : (..., ) np.ndarray
             If only requesting a single field.
         """
-        XYZ = check_ndarray_dim(XYZ)
+        XYZ = check_xyz_dim(XYZ)
         sig0 = self.sigma_background
         sig1 = self.sigma_sphere
         E0 = self.amplitude
@@ -193,7 +193,7 @@ class ElectrostaticSphere:
         E : (..., 3) np.ndarray
             If only requesting a single field.
         """
-        XYZ = check_ndarray_dim(XYZ)
+        XYZ = check_xyz_dim(XYZ)
         sig0 = self.sigma_background
         sig1 = self.sigma_sphere
         E0 = self.amplitude
@@ -241,7 +241,7 @@ class ElectrostaticSphere:
         J : (..., 3) np.ndarray
             If only requesting a single field.
         """
-        XYZ = check_ndarray_dim(XYZ)
+        XYZ = check_xyz_dim(XYZ)
 
         Et, Ep, Es = self.electric_field(XYZ, field='all')
         if field != 'total':
@@ -279,7 +279,7 @@ class ElectrostaticSphere:
         -------
         rho: (..., ) np.ndarray
         """
-        XYZ = check_ndarray_dim(XYZ)
+        XYZ = check_xyz_dim(XYZ)
 
         sig0 = self.sigma_background
         sig1 = self.sigma_sphere

--- a/geoana/em/static/sphere.py
+++ b/geoana/em/static/sphere.py
@@ -833,7 +833,7 @@ class MagnetostaticSphere:
 
         # total field outside the sphere
         Ht[ind0] = H0 * (1. - mu_cur * self.radius ** 3. / r[ind0, None] ** 3) +\
-            3. * (r_vec[ind0, None] @ H0)[..., None] * mu_cur * self.radius * r_vec[ind0] / r[ind0, None] ** 4
+            3. * (r_vec[ind0] @ H0)[..., None] * mu_cur * self.radius * r_vec[ind0] / r[ind0, None] ** 4
 
         # inside the sphere
         Ht[~ind0] = 3. * mu0 / (mu1 + 2. * mu0) * H0

--- a/geoana/em/static/sphere.py
+++ b/geoana/em/static/sphere.py
@@ -330,7 +330,7 @@ class ElectrostaticSphere:
 
         # total field outside the sphere
         Et[ind0] = E0 * (1. - sig_cur * self.radius ** 3. / r[ind0, None] ** 3) +\
-            3. * (r_vec[ind0] @ E0) * sig_cur * self.radius * r_vec[ind0] / r[ind0, None] ** 4
+            3. * (r_vec[ind0] @ E0)[..., None] * sig_cur * self.radius * r_vec[ind0] / r[ind0, None] ** 4
 
         # inside the sphere
         Et[~ind0] = 3. * sig0 / (sig1 + 2. * sig0) * E0
@@ -833,7 +833,7 @@ class MagnetostaticSphere:
 
         # total field outside the sphere
         Ht[ind0] = H0 * (1. - mu_cur * self.radius ** 3. / r[ind0, None] ** 3) +\
-            3. * r_vec[ind0, None] @ H0 * mu_cur * self.radius * r_vec[ind0] / r[ind0, None] ** 4
+            3. * (r_vec[ind0, None] @ H0)[..., None] * mu_cur * self.radius * r_vec[ind0] / r[ind0, None] ** 4
 
         # inside the sphere
         Ht[~ind0] = 3. * mu0 / (mu1 + 2. * mu0) * H0

--- a/geoana/gravity.py
+++ b/geoana/gravity.py
@@ -18,6 +18,7 @@ Simulation Classes
 
 import numpy as np
 from scipy.constants import G
+from geoana.utils import check_xyz_dim
 
 
 class PointMass:
@@ -142,7 +143,7 @@ class PointMass:
         >>> plt.title('Gravitational Potential as a function of distance from point mass')
         >>> plt.show()
         """
-
+        xyz = check_xyz_dim(xyz)
         r_vec = xyz - self.location
         r = np.linalg.norm(r_vec, axis=-1)
         u_g = (G * self.mass) / r
@@ -199,7 +200,7 @@ class PointMass:
         >>> plt.title('Gravitational Field Lines for a Point Mass')
         >>> plt.show()
         """
-
+        xyz = check_xyz_dim(xyz)
         r_vec = xyz - self.location
         r = np.linalg.norm(r_vec, axis=-1)
         g_vec = -G * self.mass * r_vec / r[..., None] ** 3
@@ -260,7 +261,7 @@ class PointMass:
         >>> ax9.contourf(X, Y, g_tens[:,:,2,2])
         >>> plt.show()
         """
-
+        xyz = check_xyz_dim(xyz)
         r_vec = xyz - self.location
         r = np.linalg.norm(r_vec, axis=-1)
         g_tens = -G * self.mass * (np.eye(3) / r[..., None, None] ** 3 -
@@ -406,7 +407,7 @@ class Sphere(PointMass):
         >>> plt.title('Gravitational Potential as a function of distance from sphere')
         >>> plt.show()
         """
-
+        xyz = check_xyz_dim(xyz)
         r_vec = xyz - self.location
         r = np.linalg.norm(r_vec, axis=-1)
         u_g = np.zeros_like(r)
@@ -472,7 +473,7 @@ class Sphere(PointMass):
         >>> plt.title('Gravitational Field Lines for a Sphere')
         >>> plt.show()
         """
-
+        xyz = check_xyz_dim(xyz)
         r_vec = xyz - self.location
         r = np.linalg.norm(r_vec, axis=-1)
         g_vec = np.zeros((*r.shape, 3))
@@ -543,7 +544,7 @@ class Sphere(PointMass):
         >>> ax9.contourf(X, Y, g_tens[:,:,2,2])
         >>> plt.show()
         """
-
+        xyz = check_xyz_dim(xyz)
         r_vec = xyz - self.location
         r = np.linalg.norm(r_vec, axis=-1)
         g_tens = np.zeros((*r.shape, 3, 3))

--- a/geoana/utils.py
+++ b/geoana/utils.py
@@ -12,6 +12,7 @@ commonly used within the code base.
 
   mkvc
   ndgrid
+  check_ndarray_dim
 
 """
 import numpy as np
@@ -151,3 +152,33 @@ def ndgrid(*args, **kwargs):
             return np.c_[X1, X2, X3]
         else:
             return XYZ[2], XYZ[1], XYZ[0]
+
+
+def check_ndarray_dim(xyz, dim=3, dtype=float):
+    """ Checks if the arguments are compatible with the expected dimensionality and type
+
+    If xyz is a list or tuple of arrays, this will attempt to stack the arrays along the
+    last dimension, ensuring all arrays are of consistent shapes with each other.
+
+    Parameters
+    ----------
+    xyz : (dim,) tuple of numpy.ndarray, or (..., dim) numpy.ndarray
+        The array to check
+    dim : int, optional
+        The expected dimensionality
+    dtype : DataType, optional
+        The requested data type for the array
+
+    Returns
+    -------
+    xyz : (..., dim) numpy.ndarray of `dtype`
+        The validated array
+    """
+    if isinstance(xyz, (tuple, list)):
+        xyz = np.stack(xyz, axis=-1)
+    xyz = np.asarray(xyz, dtype=dtype)
+    if xyz.shape[-1] != dim:
+        raise ValueError(
+            f"Unexpected dimensionality of array, expected {dim}, saw {xyz.shape[-1]}"
+        )
+    return xyz

--- a/geoana/utils.py
+++ b/geoana/utils.py
@@ -12,7 +12,7 @@ commonly used within the code base.
 
   mkvc
   ndgrid
-  check_ndarray_dim
+  check_xyz_dim
 
 """
 import numpy as np
@@ -154,7 +154,7 @@ def ndgrid(*args, **kwargs):
             return XYZ[2], XYZ[1], XYZ[0]
 
 
-def check_ndarray_dim(xyz, dim=3, dtype=float):
+def check_xyz_dim(xyz, dim=3, dtype=float):
     """ Checks if the arguments are compatible with the expected dimensionality and type
 
     If xyz is a list or tuple of arrays, this will attempt to stack the arrays along the
@@ -174,7 +174,7 @@ def check_ndarray_dim(xyz, dim=3, dtype=float):
     xyz : (..., dim) numpy.ndarray of `dtype`
         The validated array
     """
-    if isinstance(xyz, (tuple, list)):
+    if isinstance(xyz, tuple):
         xyz = np.stack(xyz, axis=-1)
     xyz = np.asarray(xyz, dtype=dtype)
     if xyz.shape[-1] != dim:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,47 @@
+import numpy as np
+from geoana.utils import check_xyz_dim
+import pytest
+
+
+def test_x_y_z_stack():
+    xyz = np.random.rand(10, 4, 3)
+    x = xyz[..., 0]
+    y = xyz[..., 1]
+    z = xyz[..., 2]
+    xyz2 = check_xyz_dim((x, y, z))
+    np.testing.assert_equal(xyz, xyz2)
+    assert xyz2.ndim == 3
+    assert xyz2.shape == (10, 4, 3)
+
+def test_good_pass_through():
+    xyz = np.random.rand(20, 2, 3)
+    xyz2 = check_xyz_dim(xyz)
+    assert xyz is xyz2
+
+def test_bad_stack():
+    x = np.random.rand(10, 2)
+    y = np.random.rand(12, 3)
+    z = np.random.rand(20, 2)
+
+    with pytest.raises(ValueError):
+        check_xyz_dim((x, y, z))
+
+def test_dtype_cast_good():
+    xyz_int = np.random.randint(0, 10, (10, 4, 3))
+
+    xyz2 = check_xyz_dim(xyz_int, dtype=float)
+    assert np.issubdtype(xyz2.dtype, float)
+    assert xyz_int is not xyz2
+
+def test_bad_dtype_cast():
+    xyz = np.random.rand(10, 3) + 1j* np.random.rand(10, 3)
+    with pytest.warns(np.ComplexWarning):
+        xyz2 = check_xyz_dim(xyz)
+    xyz = [['0', 'O', 'o']]
+    with pytest.raises(ValueError):
+        xyz2 = check_xyz_dim(xyz)
+
+def test_bad_dim():
+    xyz = np.random.rand(10, 3, 2)
+    with pytest.raises(ValueError):
+        xyz = check_xyz_dim(xyz)


### PR DESCRIPTION
Add a utility to check xyz input dimensionality and ensure it's a numpy array in the process.
Will also stack arrays along the last dimension for a tuple input.
This allows us to call functions as:
```
xyz = np.random.rand(20, 20, 3)
func(xyz)
```
or
```
x, y, z = np.mgrid[-10:10:11j, -10:10:15j, -2:20:21j]
func((x, y, z))
```
which will stack the input and throw errors if `x`, `y`, and `z` are not all the same shape input.