### PR TITLE
dipole: remove the requirement that the moment is positive

### DIFF
--- a/geoana/em/base.py
+++ b/geoana/em/base.py
@@ -413,9 +413,6 @@ class BaseMagneticDipole(BaseDipole):
         except:
             raise TypeError(f"moment must be a number, got {type(value)}")
 
-        if value <= 0.0:
-            raise ValueError("moment must be greater than 0")
-
         self._moment = value
 
 

--- a/tests/test_em_static.py
+++ b/tests/test_em_static.py
@@ -51,8 +51,6 @@ class TestEM_Static(unittest.TestCase):
         with pytest.raises(TypeError):
             self.mdws.moment = "box"
         with pytest.raises(ValueError):
-            self.mdws.moment = -2
-        with pytest.raises(ValueError):
             self.mdws.orientation = [0, 1, 2, 3, 4]
         with pytest.raises(ValueError):
             self.mdws.orientation = [[0, 0], [0, 1]]


### PR DESCRIPTION
I suggest that we remove the requirement that the moment is positive. A negative moment just means the dipole moment is in the opposite direction to the orientation. This can be very useful for testing of other codes. 