### PR TITLE
add testing on python 3.9, 3.10

### DIFF
--- a/.github/workflows/test_with_conda.yml
+++ b/.github/workflows/test_with_conda.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test_with_conda.yml
+++ b/.github/workflows/test_with_conda.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
EOSC 350 will be running on 3.10, so it would be good to know we can rely on geoana! 