### PR TITLE
small fix to catch edge cases in floating point errors.

### DIFF
--- a/geoana/kernels/_extensions/potential_field_prism.c
+++ b/geoana/kernels/_extensions/potential_field_prism.c
@@ -21,7 +21,7 @@ static void double_prism_f(char **args, const npy_intp *dimensions,
     npy_intp inx_step = steps[0], iny_step = steps[1], inz_step = steps[2];
     npy_intp out_step = steps[3];
 
-    double x, y, z, v, r;
+    double x, y, z, v, r, temp;
 
     for (i = 0; i < n; i++) {
         /* BEGIN main ufunc computation */
@@ -32,19 +32,31 @@ static void double_prism_f(char **args, const npy_intp *dimensions,
         r = sqrt(x * x + y * y + z * z);
         if (x != 0.0){
             if (y != 0.0){
-                v -= x * y * log(z + r);
+                temp = z + r;
+                // check if x & y were small relative to -z
+                if (temp > 0){
+                    v -= x * y * log(temp);
+                }
             }
             v += 0.5 * x * x * atan( y * z / (x * r));
         }
         if (y != 0.0){
             if (z != 0.0){
-                v -= y *z * log(x + r);
+                temp = x + r;
+                // check if y & z were small relative to -x
+                if (temp > 0){
+                    v -= y *z * log(temp);
+                }
             }
             v += 0.5 * y * y * atan(z * x / (y * r));
         }
         if (z != 0.0){
             if (x != 0.0){
-                v -= z * x * log(y + r);
+                temp = y + r;
+                // check if x & z were small relative to -y
+                if (temp > 0){
+                    v -= z * x * log(temp);
+                }
             }
             v += 0.5 * z * z * atan(x * y / (z * r));
         }
@@ -71,7 +83,7 @@ static void double_prism_fz(char **args, const npy_intp *dimensions,
     npy_intp inx_step = steps[0], iny_step = steps[1], inz_step = steps[2];
     npy_intp out_step = steps[3];
 
-    double x, y, z, v, r;
+    double x, y, z, v, r, temp;
 
     for (i = 0; i < n; i++) {
         /* BEGIN main ufunc computation */
@@ -81,10 +93,18 @@ static void double_prism_fz(char **args, const npy_intp *dimensions,
         v = 0.0;
         r = sqrt(x * x + y * y + z * z);
         if (x != 0.0){
-            v += x * log(y + r);
+            temp = y + r;
+            // check if x & z were small relative to -y
+            if (temp > 0.0){
+                v += x * log(temp);
+            }
         }
         if (y != 0.0){
-            v += y * log(x + r);
+            temp = x + r;
+            // check if y & z were small relative to -x
+            if (temp > 0.0){
+                v += y * log(temp);
+            }
         }
         if (z != 0.0){
             v -= z * atan(x * y / (z * r));

--- a/geoana/kernels/potential_field_prism.py
+++ b/geoana/kernels/potential_field_prism.py
@@ -23,14 +23,17 @@ def _prism_f(x, y, z):
     nz_y = y != 0.0
     nz_z = z != 0.0
 
-    nz = nz_x & nz_y
-    out[nz] -= x[nz] * y[nz] * np.log(z[nz] + r[nz])
+    temp = z + r
+    nz = nz_x & nz_y & (temp > 0.0)
+    out[nz] -= x[nz] * y[nz] * np.log(temp[nz])
 
-    nz = nz_y & nz_z
-    out[nz] -= y[nz] * z[nz] * np.log(x[nz] + r[nz])
+    temp = x + r
+    nz = nz_y & nz_z & (temp > 0.0)
+    out[nz] -= y[nz] * z[nz] * np.log(temp[nz])
 
-    nz = nz_x & nz_z
-    out[nz] -= x[nz] * z[nz] * np.log(y[nz] + r[nz])
+    temp = y + r
+    nz = nz_x & nz_z & (temp > 0.0)
+    out[nz] -= x[nz] * z[nz] * np.log(temp[nz])
 
     out[nz_x] += 0.5 * x[nz_x] * x[nz_x] * np.arctan(y[nz_x] * z[nz_x] / (x[nz_x] * r[nz_x]))
     out[nz_y] += 0.5 * y[nz_y] * y[nz_y] * np.arctan(x[nz_y] * z[nz_y] / (y[nz_y] * r[nz_y]))
@@ -60,11 +63,13 @@ def _prism_fz(x, y, z):
     r = np.sqrt(x * x + y * y + z * z)
     out = np.zeros_like(r)
 
-    nz = x != 0.0
-    out[nz] += x[nz] * np.log(y[nz] + r[nz])
+    temp = y + r
+    nz = (x != 0.0) & (temp > 0)
+    out[nz] += x[nz] * np.log(temp[nz])
 
-    nz = y != 0.0
-    out[nz] += y[nz] * np.log(x[nz] + r[nz])
+    temp = x + r
+    nz = (y != 0.0) & (temp > 0)
+    out[nz] += y[nz] * np.log(temp[nz])
 
     nz = z != 0.0
     out[nz] -= z[nz] * np.arctan(x[nz]*y[nz]/(z[nz]*r[nz]))


### PR DESCRIPTION
Was a small undetected edge case in the potential field prism kernels.
For example, it occurred when `x` or `z` was small relative to a negative `y` (or `y` and `z` were small relative to a negative `x`). If these values were close to but not exactly 0, the floating point error would cause `y + r = 0`, thus throwing an error in `log(0)`.

The fix for this is to just skip over when this condition (`y + r == 0`) happens by first checking the input to the logarithm. I favor this approach opposed to setting an arbitrary threshold on determining small values of x in order to more accurately compute the prism function when all three values (`x`, `y`, and `z`) are small.