### PR TITLE
use only year of creation for license 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2018 SimPEG Team
+Copyright (c) 2017 SimPEG Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/geoana/__init__.py
+++ b/geoana/__init__.py
@@ -5,4 +5,4 @@ from . import em
 __version__ = '0.4.0'
 __author__ = 'SimPEG developers'
 __license__ = 'MIT'
-__copyright__ = 'Copyright 2017-2018 SimPEG developers'
+__copyright__ = 'Copyright 2017 SimPEG developers'


### PR DESCRIPTION
Use only the year we created geoana for the license. This way we don't need to update every year