### PR TITLE
quasi-static-patch

### DIFF
--- a/geoana/em/base.py
+++ b/geoana/em/base.py
@@ -101,7 +101,7 @@ class BaseEM:
         except:
             raise TypeError(f"epsilon must be a number, got {type(value)}")
 
-        if value <= 0.0:
+        if value < 0.0:
             raise ValueError("epsilon must be greater than 0")
 
         self._epsilon = value


### PR DESCRIPTION
allow epsilon to be set to zero as a valid way to invoke the quasi-static assumption