### PR TITLE
libdlf

### DIFF
--- a/.github/workflows/test_with_conda.yml
+++ b/.github/workflows/test_with_conda.yml
@@ -37,7 +37,7 @@ jobs:
         conda list
         conda config --show
         conda install --quiet --yes pip numpy scipy "matplotlib>=3.5.0" ipython cython;
-        conda install --quiet --yes discretize utm "empymod>=2.0" pytest pytest-cov graphviz
+        conda install --quiet --yes discretize libdlf utm pytest pytest-cov graphviz
         pip install -r requirements_dev.txt
     - name: Install Our Package
       run: |
@@ -75,7 +75,7 @@ jobs:
         conda list
         conda config --show
         conda install --quiet --yes pip numpy scipy "matplotlib>=3.5.0" ipython cython;
-        conda install --quiet --yes discretize utm empymod pytest pytest-cov graphviz
+        conda install --quiet --yes discretize libdlf utm pytest pytest-cov graphviz
         pip install -r requirements_dev.txt
     - name: Prepare source distribution
       run: |

--- a/setup.py
+++ b/setup.py
@@ -53,9 +53,8 @@ metadata = dict(
     install_requires = [
         'numpy>=1.8',
         'scipy>=0.13',
-        'matplotlib',
+        'libdlf'
         'utm',
-        'empymod>=2.0'
     ],
     author = 'SimPEG developers',
     author_email = 'lindseyheagy@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ metadata = dict(
     install_requires = [
         'numpy>=1.8',
         'scipy>=0.13',
-        'libdlf'
+        'libdlf',
         'utm',
     ],
     author = 'SimPEG developers',


### PR DESCRIPTION
This changes the requirements from `empymod` to `libdlf`.

We were only using `empymod` to essentially define the filter anyways. The `libdlf` library only has `numpy` as a dependancy, so it should eliminate the implied requirement `numba`.