### PR TITLE
make utm and matplotlib optional

### DIFF
--- a/geoana/earthquake/oksar.py
+++ b/geoana/earthquake/oksar.py
@@ -15,9 +15,17 @@ Heritage:
 """
 
 import numpy as np
-import utm
-import matplotlib.pyplot as plt
+try:
+    import utm
+except ImportError:
+    utm = False
+try:
+    import matplotlib.pyplot as plt
+    matplotlib = True
+except ImportError:
+    matplotlib = False
 from datetime import datetime
+from geoana.utils import requires
 
 def _date_time_from_json(value):
     if len(value) == 10:
@@ -671,6 +679,7 @@ class EarthquakeInterferogram:
 
         return vectorNx, vectorNy, data
 
+    @requires({"matplotlib": matplotlib})
     def plot_interferogram(self, wrap=True, ax=None):
         """Plot interferogram
 
@@ -724,6 +733,7 @@ class EarthquakeInterferogram:
 
         return out
 
+    @requires({"matplotlib": matplotlib})
     def plot_mask(self, ax=None, opacity=0.2):
         """Plot masked interferogram
 
@@ -766,6 +776,7 @@ class EarthquakeInterferogram:
 
         return out
 
+    @requires({"utm":utm})
     def get_LOS_vector(self, locations):
         """calculate beta - the angle at earth center between reference point
         and satellite nadir
@@ -1514,6 +1525,7 @@ class Oksar:
                     u = - du + u
         return u
 
+    @requires({"matplotlib": matplotlib})
     def plot_displacement(self, eq=None, ax=None, wrap=True, mask_opacity=0.2):
         """Plot displacement/
 

--- a/geoana/plotting_utils.py
+++ b/geoana/plotting_utils.py
@@ -16,11 +16,16 @@ data computed with geoana.
 
 import numpy as np
 from scipy.interpolate import LinearNDInterpolator, NearestNDInterpolator
-import matplotlib.pyplot as plt
-from matplotlib import colors
-import warnings
+from .utils import requires
+try:
+    import matplotlib.pyplot as plt
+    from matplotlib import colors
+    matplotlib = True
+except ImportError:
+    matplotlib = False
 
 
+@requires({"matplotlib": matplotlib})
 def plot2Ddata(
     xyz,
     data,

--- a/geoana/utils.py
+++ b/geoana/utils.py
@@ -180,3 +180,45 @@ def check_xyz_dim(xyz, dim=3, dtype=float):
             f"Unexpected dimensionality of array, expected {dim}, saw {xyz.shape[-1]}"
         )
     return xyz
+
+
+def requires(modules):
+    """Decorate a function with soft dependencies.
+
+    This function was inspired by the `requires` function of pysal,
+    which is released under the 'BSD 3-Clause "New" or "Revised" License'.
+
+    https://github.com/pysal/pysal/blob/master/pysal/lib/common.py
+
+    Parameters
+    ----------
+    modules : dict
+        Dictionary containing soft dependencies, e.g.,
+        {'matplotlib': matplotlib}.
+
+    Returns
+    -------
+    decorated_function : function
+        Original function if all soft dependencies are met, otherwise
+        it returns an empty function which prints why it is not running.
+
+    """
+    # Check the required modules, add missing ones in the list `missing`.
+    missing = []
+    for key, item in modules.items():
+        if item is False:
+            missing.append(key)
+
+    def decorated_function(function):
+        """Wrap function."""
+        if not missing:
+            return function
+        else:
+
+            def passer(*args, **kwargs):
+                print(("Missing dependencies: {d}.".format(d=missing)))
+                print(("Not running `{}`.".format(function.__name__)))
+
+            return passer
+
+    return decorated_function

--- a/setup.py
+++ b/setup.py
@@ -45,16 +45,15 @@ with open('README.rst') as f:
 metadata = dict(
     name = 'geoana',
     version = '0.4.1',
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     setup_requires=[
         "numpy>=1.8",
-        "cython>=0.2",
+        "cython>=0.29",
     ],
     install_requires = [
-        'numpy>=1.8',
-        'scipy>=0.13',
+        "numpy>=1.20",
+        "scipy>=1.8",
         'libdlf',
-        'utm',
     ],
     author = 'SimPEG developers',
     author_email = 'lindseyheagy@gmail.com',


### PR DESCRIPTION
Makes `utm` and `matplotlib` optional dependencies for `geoana`.

* `utm` was being used in the `earthquake` module,
* `matplotlib` was being used in the `earthquake` and `plotting_utils` modules.