### PR TITLE
Fix misleading error message for epsilon values

### DIFF
--- a/geoana/em/base.py
+++ b/geoana/em/base.py
@@ -102,7 +102,10 @@ class BaseEM:
             raise TypeError(f"epsilon must be a number, got {type(value)}")
 
         if value < 0.0:
-            raise ValueError("epsilon must be greater than 0")
+            raise ValueError(
+                f"Invalid epsilon '{value}': "
+                "epsilon must be greater or equal than than zero."
+            )
 
         self._epsilon = value
 

--- a/geoana/em/base.py
+++ b/geoana/em/base.py
@@ -104,7 +104,7 @@ class BaseEM:
         if value < 0.0:
             raise ValueError(
                 f"Invalid epsilon '{value}': "
-                "epsilon must be greater or equal than than zero."
+                "epsilon must be greater or equal than zero."
             )
 
         self._epsilon = value


### PR DESCRIPTION
In `BaseEM` class, epsilon properties are allowed to be zero or
positive, although the error message stated that epsilon should be
greater than zero. Fix the error message to agree with the implemented
logic and also print the offending value.
