### PR TITLE
Add numpy dependency fallback necessary for cross-compilation builds

### DIFF
--- a/geoana/kernels/_extensions/meson.build
+++ b/geoana/kernels/_extensions/meson.build
@@ -1,7 +1,37 @@
 
+numpy_nodepr_api = ['-DNPY_NO_DEPRECATED_API=NPY_1_22_API_VERSION']
+
 # NumPy include directory
-np_dep = dependency('numpy')
-numpy_nodepr_api = ['-DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION']
+np_dep = dependency('numpy', required: false)
+if not np_dep.found()
+  # For cross-compilation it is often not possible to run the Python interpreter
+  # in order to retrieve numpy's include directory. It can be specified in the
+  # cross file instead:
+  #   [properties]
+  #   numpy-include-dir = /abspath/to/host-pythons/site-packages/numpy/core/include
+  #
+  # This uses the path as is, and avoids running the interpreter.
+  incdir_numpy = meson.get_external_property('numpy-include-dir', 'not-given')
+  if incdir_numpy == 'not-given'
+    incdir_numpy = run_command(py,
+      [
+        '-c',
+        '''import os
+import numpy as np
+try:
+  incdir = os.path.relpath(np.get_include())
+except Exception:
+  incdir = np.get_include()
+print(incdir)
+    '''
+      ],
+      check: true
+    ).stdout().strip()
+  endif
+  inc_np = include_directories(incdir_numpy)
+  np_dep = declare_dependency(include_directories: inc_np)
+endif
+
 
 # Deal with M_PI & friends; add `use_math_defines` to c_args or cpp_args
 # Cython doesn't always get this right itself (see, e.g., gh-16800), so

--- a/geoana/kernels/_extensions/meson.build
+++ b/geoana/kernels/_extensions/meson.build
@@ -45,6 +45,11 @@ endif
 
 c_undefined_ok = ['-Wno-maybe-uninitialized']
 
+cython_args = []
+if cy.version().version_compare('>=3.1.0')
+  cython_args += ['-Xfreethreading_compatible=True']
+endif
+
 cython_c_args = [numpy_nodepr_api, use_math_defines]
 
 cython_cpp_args = cython_c_args
@@ -54,6 +59,7 @@ module_path = 'geoana/kernels/_extensions'
 py.extension_module(
     'potential_field_prism',
     'potential_field_prism.pyx',
+    cython_args: cython_args,
     c_args: cython_c_args,
     install: true,
     subdir: module_path,
@@ -63,6 +69,7 @@ py.extension_module(
 py.extension_module(
     'rTE',
     ['rTE.pyx', '_rTE.cpp'],
+    cython_args: cython_args,
     cpp_args: cython_cpp_args,
     install: true,
     subdir: module_path,


### PR DESCRIPTION
Most cross-compilation builds are not able to make use of meson's `numpy_config` script to find the necessary header files, (See https://github.com/conda-forge/geoana-feedstock/pull/34 where I was testing this before releasing a new version.)

I wasn't quite sure if it was able to do it or not (but I suspected it wasn't). So this adds a fallback method of determining the `numpy` include directory incase the normal lookup fails. So this addition follows what `pywt` does. (see here: https://github.com/PyWavelets/pywt/blob/361cc9a4c80bc2603fae99e151f2a391c0b376f9/pywt/_extensions/meson.build#L13)