### PR TITLE
small bugfix in the equation as brought in from ward and hohmann

### DIFF
--- a/geoana/em/tdem/simple_functions.py
+++ b/geoana/em/tdem/simple_functions.py
@@ -153,7 +153,7 @@ def vertical_magnetic_field_time_deriv_horizontal_loop(
     Matches equation 4.97 of Ward and Hohmann 1988.
 
     .. math::
-        \\frac{\\partial h_z}{\\partial t} = -\\frac{I}{\\sigma a^3}\\left[
+        \\frac{\\partial h_z}{\\partial t} = -\\frac{I}{\\mu_0 \\sigma a^3}\\left[
         3 \\mathrm{erf}(\\theta a)
         - \\frac{2}{\\sqrt{\\pi}}\\theta a (3 + 2 \\theta^2 a^2)e^{-\\theta^2 a^2}
         \\right]


### PR DESCRIPTION
We are missing a $\mu_0$ in the documentation for the TDEM dh/dt equation 

<img width="1068" height="140" alt="image" src="https://github.com/user-attachments/assets/437f9c95-65b0-4d84-8b58-5c54474070eb" />

And the `mu` is correctly there in the code: 

https://github.com/simpeg/geoana/blob/f17537c6fd26c98a16cf639d5ad459ababbe2df8/geoana/em/tdem/simple_functions.py#L184